### PR TITLE
Loosen dep bound

### DIFF
--- a/text-render.cabal
+++ b/text-render.cabal
@@ -21,6 +21,6 @@ library
   hs-source-dirs:      src
 -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.9, text, parsec, mtl, classy-prelude
+  build-depends:       base >=4.8 && < 5, text, parsec, mtl, classy-prelude
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
This change relaxes the dependency bound on `base` just a bit so that the package can build with GHC 8.0.2; I tested that this cabal package with my change builds with Nix using GHC 8.0.2.